### PR TITLE
several mouse functions for widget, enable/disable widget

### DIFF
--- a/bl_ui_button.py
+++ b/bl_ui_button.py
@@ -166,8 +166,8 @@ class BL_UI_Button(BL_UI_Widget):
             self.__state = 1
             try:
                 self.mouse_down_func(self)
-            except:
-                pass
+            except Exception as e:
+                print(e)
                 
             return True
         

--- a/bl_ui_draw_op.py
+++ b/bl_ui_draw_op.py
@@ -53,13 +53,20 @@ class BL_UI_OT_draw_operator(Operator):
     def handle_widget_events(self, event):
         result = False
         for widget in self.widgets:
-            if widget.handle_event(event):
+            if widget.enabled and widget.handle_event(event):
                 result = True
         return result
           
     def modal(self, context, event):
 
         if self._finished:
+            return {'FINISHED'}
+
+        # this ends the UI when context has changed
+        #  - by maximizing area
+        #  - by switching viewport layout.
+        if not context.area:
+            self.finish()
             return {'FINISHED'}
 
         if context.area:
@@ -80,4 +87,5 @@ class BL_UI_OT_draw_operator(Operator):
 	# Draw handler to paint onto the screen
     def draw_callback_px(self, op, context):
         for widget in self.widgets:
-            widget.draw()
+            if widget.enabled:
+                widget.draw()

--- a/bl_ui_widget.py
+++ b/bl_ui_widget.py
@@ -1,5 +1,6 @@
 import gpu
 import bgl
+import bpy
 
 from gpu_extras.batch import batch_for_shader
 
@@ -17,6 +18,7 @@ class BL_UI_Widget:
         self.context = None
         self.__inrect = False
         self._mouse_down = False
+        self.enabled = True
 
     def set_location(self, x, y):
         self.x = x
@@ -112,8 +114,10 @@ class BL_UI_Widget:
     def get_input_keys(self)                :
         return []
 
+
+
     def get_area_height(self):
-        return self.context.area.height    
+        return self.context.area.height
 
     def is_in_rect(self, x, y):
         area_height = self.get_area_height()
@@ -136,11 +140,50 @@ class BL_UI_Widget:
     def mouse_up(self, x, y):
         pass
 
+    def set_mouse_enter(self, mouse_enter_func):
+        self.mouse_enter_func = mouse_enter_func
+
+    def mouse_enter_func(self):
+        pass
+
     def mouse_enter(self, event, x, y):
+        try:
+            self.mouse_enter_func(self)
+        except Exception as e:
+            print(e)
+
+        return True
+
+    def set_mouse_exit(self, mouse_exit_func):
+        self.mouse_exit_func = mouse_exit_func
+
+    def mouse_exit_func(self):
         pass
 
     def mouse_exit(self, event, x, y):
+        try:
+            self.mouse_exit_func(self)
+        except Exception as e:
+            print(e)
+
+        return True
+
+    def set_mouse_move(self, mouse_move_func):
+        self.mouse_move_func = mouse_move_func
+
+    def mouse_move_func(self):
         pass
 
-    def mouse_move(self, x, y):
-        pass
+    def mouse_move(self, event, x, y):
+        if self.is_in_rect(x, y):
+            try:
+                self.mouse_move_func(self)
+            except Exception as e:
+                print(e)
+        return True
+
+    def enable(self):
+        self.enabled = True
+
+    def disable(self):
+        self.enabled = False


### PR DESCRIPTION
mouse enter, exit, move now can have functions assigned
enable -disable widget unctions - hide and disable the widget
Try to fix the error when the area gets maximized - the operator finishes.

This is the very first commit/pull request. I expect maybe you'd want to do different naming standards and it's possible I didn't as of now understood completely the structure of the library.
The mouse move/enter/exit functions are for being able to display a custom tooltip.
The enable-disable is to dynamically change the buttons in the panel - maybe there is a different way to do this?